### PR TITLE
global leaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ function throughPauseSpec (mac, stream, opts) {
   demand that the stream does not emit any data when paused
 */
 function pauseSpec (mac, stream, opts) {
-  paused = false
+  var paused = false
   function e (n) { return opts.name + '.emit(\''+n+'\')' }
   function n (n) { return opts.name + '.'+n+'()' }
 


### PR DESCRIPTION
I am using stream-spec for a project with mocha, and mocha was complaining about a global leak (`Error: global leak detected: paused`). This turned out to be in the `pauseSpec` function, that did not include a `var` before the paused variable was declared.
