### PR TITLE
Valid SPDX identifier/expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,5 @@
     "macgyver": "~1.10"
   },
   "author": "Dominic Tarr",
-  "license": [
-    "MIT",
-    "Apache2"
-  ]
+  "license": "(MIT OR Apache-2.0)"
 }


### PR DESCRIPTION
The `license` property requires a valid SPDX 2.0 expression. This SPDX `(... OR ...)` syntax is demonstrated in the [NPM documentation](https://docs.npmjs.com/files/package.json#license). The changed identifier `Apache-2.0` is from the [SPDX License List](http://spdx.org/licenses/) page.
